### PR TITLE
feat: Implement setting CORS config option via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ To start the server without compiling again, use `npm run production` only.
 
 This project is available as a Docker image! See also [https://hub.docker.com/r/meyfa/ka-mensa-api](https://hub.docker.com/r/meyfa/ka-mensa-api).
 
+### Running the Container
+
 If you just want to get going:
 
 ```sh
@@ -92,6 +94,25 @@ docker run \
         -v /path/on/host:/usr/src/app/cache \
         -d meyfa/ka-mensa-api
 ```
+
+### CORS Headers
+
+Perhaps you need to configure CORS for the API server - to enable displaying
+the plans via an instance of `ka-mensa-ui` running on another domain, for
+example. This can be done via the config file or by setting an environment
+variable:
+
+```
+docker run \
+        --name mensa \
+        -p <host-port>:8080 \
+        -v /path/on/host:/usr/src/app/cache \
+        -e API_SERVER_CORS_ALLOWORIGIN=https://example.com \
+        -d meyfa/ka-mensa-api
+```
+
+Specify a regular URL to only allow that one origin. Use `*` to allow all
+origins.
 
 
 ## Development

--- a/server.ts
+++ b/server.ts
@@ -10,6 +10,19 @@ import { indexRoute } from './routes'
 import { logger } from './logger'
 
 /**
+ * Determine the CORS origin to allow, from either the environment variables or the config.
+ * This function will return a string if and only if the option is set and is not empty.
+ *
+ * @returns The origin value, if it is valid, and undefined otherwise.
+ */
+function getAllowOrigin (): string | undefined {
+  return [
+    process.env.API_SERVER_CORS_ALLOWORIGIN,
+    config.server.cors?.allowOrigin
+  ].find(value => value != null && value !== '')
+}
+
+/**
  * Start the server.
  */
 async function start (): Promise<void> {
@@ -25,10 +38,9 @@ async function start (): Promise<void> {
 
   // setup server and routes
   const app = express()
-  if (config.server.cors?.allowOrigin != null && config.server.cors.allowOrigin !== '') {
-    app.use(cors({
-      origin: config.server.cors.allowOrigin
-    }))
+  const allowOrigin = getAllowOrigin()
+  if (allowOrigin != null) {
+    app.use(cors({ origin: allowOrigin }))
   }
   app.use(config.server.base, indexRoute(cache))
 


### PR DESCRIPTION
Setting `API_SERVER_CORS_ALLOWORIGIN` can override the config option.
This should make it easier to configure CORS in a Docker cluster.