### PR TITLE
chore(ci): Add "tsc --noEmit" to lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "npm run build && npm run production",
     "build": "rimraf dist && tsc",
     "production": "node dist/server.js",
-    "lint": "eslint --ignore-path .gitignore .",
-    "lint-fix": "eslint --fix --ignore-path .gitignore .",
+    "lint": "eslint --ignore-path .gitignore . && tsc --noEmit",
+    "lint-fix": "eslint --fix --ignore-path .gitignore . && tsc --noEmit",
     "test": "mocha --require ts-node/register --recursive \"test/**/*.test.*\""
   },
   "repository": {


### PR DESCRIPTION
This ensures that the code is valid according to TypeScript, not just
according to ESLint, which usually does not do type-checking.