### PR TITLE
refactor!: Convert everything to ESM and increment minimum Node version

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,6 +12,8 @@ overrides:
       '@typescript-eslint/no-unused-expressions': off
 
 rules:
+  # this project requires .js extensions with imports because it is packaged as ESM:
+  import/extensions: [error, always]
   # require JSDoc on every standard location, and also on classes, interfaces and enums
   jsdoc/require-jsdoc: ['error', { contexts: ['ClassDeclaration', 'TSInterfaceDeclaration', 'TSEnumDeclaration'] }]
   jsdoc/require-param-type: off

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  loader: 'ts-node/esm'
+}

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'node:path'
 
 export default {
   server: {

--- a/controllers/canteens-controller.ts
+++ b/controllers/canteens-controller.ts
@@ -1,7 +1,8 @@
+import { createRequire } from 'node:module'
 import { Canteen, Line } from 'ka-mensa-fetch'
-import canteens from 'ka-mensa-fetch/data/canteens.json'
+import { NotFoundError } from '../lib/errors.js'
 
-import { NotFoundError } from '../lib/errors'
+const canteens: Canteen[] = createRequire(import.meta.url)('ka-mensa-fetch/data/canteens.json')
 
 // CONSTANTS
 

--- a/controllers/legend-controller.ts
+++ b/controllers/legend-controller.ts
@@ -1,5 +1,7 @@
+import { createRequire } from 'node:module'
 import { LegendItem } from 'ka-mensa-fetch'
-import legend from 'ka-mensa-fetch/data/legend.json'
+
+const legend: LegendItem[] = createRequire(import.meta.url)('ka-mensa-fetch/data/legend.json')
 
 /**
  * API controller for retrieving the legend.

--- a/controllers/plans-controller.ts
+++ b/controllers/plans-controller.ts
@@ -1,7 +1,6 @@
 import { CanteenLine, CanteenPlan, DateSpec } from 'ka-mensa-fetch'
-
-import { Cache } from '../lib/cache'
-import { NotFoundError } from '../lib/errors'
+import { Cache } from '../lib/cache.js'
+import { NotFoundError } from '../lib/errors.js'
 
 // TYPES
 

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,6 +1,5 @@
 import moment from 'moment'
-
-import { parseDate } from './util/parse-date'
+import { parseDate } from './util/parse-date.js'
 import { Adapter } from 'fs-adapters'
 import { CanteenPlan, DateSpec } from 'ka-mensa-fetch'
 

--- a/lib/create-handler.ts
+++ b/lib/create-handler.ts
@@ -1,6 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
-import { ApiError } from './errors'
-import { logger } from './logger'
+import { ApiError } from './errors.js'
+import { logger } from './logger.js'
 
 /**
  * Respond with an error message.

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,6 +1,6 @@
 /**
  * A special type of error that is intentionally thrown by the API.
- * It includes a HTTP status code and a message string.
+ * It includes an HTTP status code and a message string.
  *
  * Any error not inheriting from this class will be considered a bug and results in status code 500 to be sent,
  * without revealing the error message.

--- a/lib/job.ts
+++ b/lib/job.ts
@@ -2,12 +2,10 @@ import { CanteenPlan, DateSpec, fetchMensa } from 'ka-mensa-fetch'
 import { group } from 'group-items'
 import moment from 'moment'
 import ms from 'ms'
-
-import config from '../config'
-
-import { getSessionCookie } from './get-session-cookie'
-import { Cache } from './cache'
-import { logger } from './logger'
+import config from '../config.js'
+import { getSessionCookie } from './get-session-cookie.js'
+import { Cache } from './cache.js'
+import { logger } from './logger.js'
 
 // CONSTANTS
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "ka-mensa-api",
   "version": "0.0.0",
   "description": "Karlsruhe (KIT) Mensa API server",
+  "type": "module",
   "main": "dist/server.js",
   "scripts": {
     "start": "npm run build && npm run production",
@@ -11,7 +12,7 @@
     "lint": "eslint --ignore-path .gitignore . && tsc --noEmit",
     "lint-fix": "eslint --fix --ignore-path .gitignore . && tsc --noEmit",
     "coverage": "c8 --reporter=lcov --reporter=text --all --include \"**/*.ts\" npm test",
-    "test": "mocha --require ts-node/register --recursive \"test/**/*.test.*\""
+    "test": "mocha --recursive \"test/**/*.test.*\""
   },
   "repository": {
     "type": "git",
@@ -30,7 +31,7 @@
   },
   "homepage": "https://github.com/meyfa/ka-mensa-api",
   "engines": {
-    "node": ">=10.0.0"
+    "node": "^14.13.1 || >=16.0.0"
   },
   "dependencies": {
     "cors": "2.8.5",

--- a/routes/canteens.ts
+++ b/routes/canteens.ts
@@ -1,8 +1,7 @@
 import { Request, Router } from 'express'
-
-import { Cache } from '../lib/cache'
-import { CanteensController } from '../controllers/canteens-controller'
-import { createHandler } from '../lib/create-handler'
+import { Cache } from '../lib/cache.js'
+import { CanteensController } from '../controllers/canteens-controller.js'
+import { createHandler } from '../lib/create-handler.js'
 
 // ROUTES FACTORY
 

--- a/routes/default.ts
+++ b/routes/default.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express'
-
-import { Cache } from '../lib/cache'
-import { createHandler } from '../lib/create-handler'
+import { Cache } from '../lib/cache.js'
+import { createHandler } from '../lib/create-handler.js'
 
 /**
  * Create the router for retrieving API status information.

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -1,13 +1,11 @@
 import { Router } from 'express'
-
-import { Cache } from '../lib/cache'
-
-import { defaultRoute } from './default'
-import { metaRoute } from './meta'
-import { canteensRoute } from './canteens'
-import { plansRoute } from './plans'
-import { createHandler } from '../lib/create-handler'
-import { NotFoundError } from '../lib/errors'
+import { Cache } from '../lib/cache.js'
+import { defaultRoute } from './default.js'
+import { metaRoute } from './meta/index.js'
+import { canteensRoute } from './canteens.js'
+import { plansRoute } from './plans.js'
+import { createHandler } from '../lib/create-handler.js'
+import { NotFoundError } from '../lib/errors.js'
 
 /**
  * Create the router that combines all other routes.

--- a/routes/meta/index.ts
+++ b/routes/meta/index.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express'
-
-import { Cache } from '../../lib/cache'
-import { legendRoute } from './legend'
+import { Cache } from '../../lib/cache.js'
+import { legendRoute } from './legend.js'
 
 /**
  * Create the router that combines meta information routes.

--- a/routes/meta/legend.ts
+++ b/routes/meta/legend.ts
@@ -1,8 +1,7 @@
 import { Router } from 'express'
-
-import { Cache } from '../../lib/cache'
-import { LegendController } from '../../controllers/legend-controller'
-import { createHandler } from '../../lib/create-handler'
+import { Cache } from '../../lib/cache.js'
+import { LegendController } from '../../controllers/legend-controller.js'
+import { createHandler } from '../../lib/create-handler.js'
 
 /**
  * Create the router for retrieving legend meta information.

--- a/routes/plans.ts
+++ b/routes/plans.ts
@@ -1,14 +1,14 @@
+import { createRequire } from 'node:module'
 import { Request, Router } from 'express'
+import { Canteen, DateSpec } from 'ka-mensa-fetch'
+import { Cache } from '../lib/cache.js'
+import { parseDate } from '../lib/util/parse-date.js'
+import { PlansController } from '../controllers/plans-controller.js'
+import { createHandler } from '../lib/create-handler.js'
+import { BadRequestError } from '../lib/errors.js'
+import { parseCommaFilter } from '../lib/util/parse-comma-filter.js'
 
-import { DateSpec } from 'ka-mensa-fetch'
-import canteens from 'ka-mensa-fetch/data/canteens.json'
-
-import { Cache } from '../lib/cache'
-import { parseDate } from '../lib/util/parse-date'
-import { PlansController } from '../controllers/plans-controller'
-import { createHandler } from '../lib/create-handler'
-import { BadRequestError } from '../lib/errors'
-import { parseCommaFilter } from '../lib/util/parse-comma-filter'
+const canteens: Canteen[] = createRequire(import.meta.url)('ka-mensa-fetch/data/canteens.json')
 
 // CONSTANTS
 

--- a/server.ts
+++ b/server.ts
@@ -1,14 +1,13 @@
-import { constants } from 'os'
+import { constants } from 'node:os'
 import express from 'express'
 import ms from 'ms'
 import cors from 'cors'
 import { DirectoryAdapter } from 'fs-adapters'
-
-import config from './config'
-import { Cache } from './lib/cache'
-import { runFetchJob } from './lib/job'
-import { indexRoute } from './routes'
-import { logger } from './lib/logger'
+import config from './config.js'
+import { Cache } from './lib/cache.js'
+import { runFetchJob } from './lib/job.js'
+import { indexRoute } from './routes/index.js'
+import { logger } from './lib/logger.js'
 
 /**
  * Determine the CORS origin to allow, from either the environment variables or the config.

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,6 +1,5 @@
-import { Cache } from '../lib/cache'
+import { Cache } from '../lib/cache.js'
 import { MemoryAdapter } from 'fs-adapters'
-
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 

--- a/test/util/parse-date.test.ts
+++ b/test/util/parse-date.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
-
-import { parseDate } from '../../lib/util/parse-date'
+import { parseDate } from '../../lib/util/parse-date.js'
 
 describe('parse-date.ts', function () {
   it('parses valid dates', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "strict": true,
     "outDir": "./dist"
   },


### PR DESCRIPTION
More and more of the ecosystem is moving ESM support for modules, and
with good reason. The point is that it's possible to import both ESM and
CommonJS modules from an ESM application, while a CommonJS application
can ony ever import CommonJS. ka-mensa-api so far has been built
around CommonJS. This means we were limited in the types of libraries
we could use. This is no longer the case. :)

Loading of the ka-mensa-fetch data files (canteens.json, legend.json)
provided a bit of a hurdle, but was easily solved with manually creating
a require() function.