### PR TITLE
chore(ci): Test on Node.js 18, and no longer on 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,15 +10,11 @@ jobs:
   lint:
     name: Linting
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version:
-          - 16
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -29,9 +25,9 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 18
           - 16
           - 14
-          - 12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -48,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - uses: paambaati/codeclimate-action@v3.0.0


### PR DESCRIPTION
Note that Node 12 was kind of unsupported already due to the engines
field in package.json.