### PR TITLE
ci: Configure docker workflow concurrency

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: CI to Docker Hub
 
+# Prevent two instances of this workflow running at the same time
+concurrency: docker-publish
+
 on:
   push:
     branches:


### PR DESCRIPTION
This is to prevent multiple publish workflows running at the same time and causing race conditions (and/or doing unnecessary work).