### PR TITLE
feat: Log which plans are being cached

### DIFF
--- a/lib/create-handler.ts
+++ b/lib/create-handler.ts
@@ -49,7 +49,7 @@ export function createHandler (fn: (req: Request) => any): RequestHandler {
       sendResult(res, result)
     } catch (error) {
       if (!(error instanceof ApiError)) {
-        logger.log('error', error)
+        logger.error(error)
         sendError(res, 500, 'internal error')
         return
       }

--- a/lib/job.ts
+++ b/lib/job.ts
@@ -101,13 +101,13 @@ async function fetchFromSource (source: string): Promise<CanteenPlan[]> {
  */
 export async function runFetchJob (cache: Cache): Promise<void> {
   const source = config.fetchJob.source
-  logger.log('info', 'fetching plans (source=' + source + ')')
+  logger.info(`fetching plans (source=${source})`)
 
   let plans
   try {
     plans = await fetchFromSource(source)
   } catch (e) {
-    logger.log('error', e)
+    logger.error(e)
     return
   }
 
@@ -118,9 +118,13 @@ export async function runFetchJob (cache: Cache): Promise<void> {
     // check for invalid date
     if (now.diff(date) > PLAN_AGE_MAXIMUM) {
       const formattedDate: string = moment(date).format('YYYY-MM-DD')
-      logger.log('warn', 'fetched a plan from ' + formattedDate + ' that was not stored due to its age')
+      logger.warn(`data for ${formattedDate} will not be stored due to its age`)
       continue
     }
+
+    const dateString = moment(date).format('YYYY-MM-DD')
+    const canteensList = plansForDate.map(plan => plan.id).join(',')
+    logger.info(`caching ${dateString} with ${plansForDate.length} canteens: [${canteensList}]`)
 
     await cache.put(date, plansForDate)
   }

--- a/server.ts
+++ b/server.ts
@@ -56,7 +56,7 @@ async function startServer (cache: Cache): Promise<void> {
   const host = config.server.host
   const server = await promisifiedListen(app, port, host)
 
-  logger.log('info', `Server listening on :${port}`)
+  logger.info(`Server listening on :${port}`)
 
   onTermination(async () => await promisifiedClose(server))
 }


### PR DESCRIPTION
This patch adds more detailed logging inside the fetch job. This is
helpful when trying to investigate at which point plan fetching has
stopped working (in cases when it does).