### PR TITLE
feat: Add fixup to infer missing data in previously cached plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ Note that `npm start` is shortcut for `npm run build` followed by `npm run produ
 where the former compiles the TypeScript code and the latter executes it.
 To start the server without compiling again, use `npm run production` only.
 
+A fixup job will run at startup. This fills in missing data that might have
+been missing at cache time but is now inferrable due to an updated data set.
+Any plans that are considered complete, or that cannot be inferred further,
+will not be changed.
+
 
 ## Setup with Docker
 
-This project is available as a Docker image! See also [https://hub.docker.com/r/meyfa/ka-mensa-api](https://hub.docker.com/r/meyfa/ka-mensa-api).
+This project is available as a Docker image! See also
+[https://hub.docker.com/r/meyfa/ka-mensa-api](https://hub.docker.com/r/meyfa/ka-mensa-api).
 
 ### Running the Container
 

--- a/src/fixup.ts
+++ b/src/fixup.ts
@@ -1,0 +1,50 @@
+import { CanteenPlan, DateSpec, matchCanteenByName, matchLineByName } from 'ka-mensa-fetch'
+import { Cache } from './cache.js'
+
+/**
+ * Fix a single plan. This fills in missing data (specifically: IDs) by matching it against existing data
+ * (specifically: human-readable names).
+ *
+ * Plans that are already complete, or cannot be fixed, will be returned unchanged by identity.
+ * Plans that were fixed will be returned as a new object.
+ *
+ * @param plan The plan to fix.
+ * @returns The same plan if unchanged, or a copy with fixed data.
+ */
+function fixup (plan: CanteenPlan): CanteenPlan {
+  const canteenId = plan.id ?? matchCanteenByName(plan.name) ?? null
+  if (canteenId == null) {
+    // Canteen id cannot be fixed, and neither can line names without a canteen id for context.
+    return plan
+  }
+  const lines = plan.lines.map(line => ({ ...line, id: line.id ?? matchLineByName(canteenId, line.name) ?? null }))
+  if (canteenId === plan.id && plan.lines.every((line, index) => line.id === lines[index].id)) {
+    // Nothing to fix.
+    return plan
+  }
+  return { ...plan, id: canteenId, lines }
+}
+
+/**
+ * Fix all plans stored in the cache. This fills in missing data that might have been missing at cache time but is now
+ * inferrable due to an updated data set. Any plans that are considered complete, or that cannot be inferred further,
+ * will not be changed.
+ *
+ * The callback is invoked for any plan about to be changed. It can be used for logging. Additionally, returning 'false'
+ * from the callback will prevent the plan from being written back out, e.g. for a dry-run.
+ *
+ * @param cache The cache to operate on.
+ * @param callback The callback predicate, which may also have side effects.
+ */
+export async function fixupCache (cache: Cache, callback: ((date: DateSpec) => boolean) = () => true): Promise<void> {
+  for (const date of await cache.list()) {
+    const plans = await cache.get(date)
+    if (plans == null) {
+      continue
+    }
+    const fixedPlans = plans.map(plan => fixup(plan))
+    if (fixedPlans.some((fixedPlan, index) => fixedPlan !== plans[index]) && callback(date)) {
+      await cache.put(date, fixedPlans)
+    }
+  }
+}

--- a/test/fixup.test.ts
+++ b/test/fixup.test.ts
@@ -1,0 +1,236 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { Cache } from '../src/cache.js'
+import { MemoryAdapter, ReadWriteOptions } from 'fs-adapters'
+import { CanteenPlan, canteens, DateSpec } from 'ka-mensa-fetch'
+import { fixupCache } from '../src/fixup.js'
+
+chai.use(chaiAsPromised)
+
+/**
+ * An extension of in-memory file storage that also tracks all write operations, for asserting in tests.
+ */
+class TestMemoryAdapter extends MemoryAdapter {
+  public writeOperations: string[] = []
+
+  override async write (fileName: string, data: Buffer | string, options?: ReadWriteOptions): Promise<void> {
+    this.writeOperations.push(fileName)
+    return await super.write(fileName, data, options)
+  }
+}
+
+describe('fixup.ts', function () {
+  before(function () {
+    // If these assumptions don't hold, the tests would break.
+    expect(canteens.length).to.be.greaterThanOrEqual(2)
+    expect(canteens[0].lines.length).to.be.greaterThanOrEqual(2)
+  })
+
+  // Plan factory functions (for test data)
+  type TestPlansFactory = (date: DateSpec) => CanteenPlan[]
+
+  const good: TestPlansFactory = (date) => [{
+    id: canteens[0].id,
+    name: canteens[0].name,
+    date,
+    lines: [{
+      id: canteens[0].lines[0].id,
+      name: canteens[0].lines[0].name,
+      meals: []
+    }, {
+      id: canteens[0].lines[1].id,
+      name: canteens[0].lines[1].name,
+      meals: []
+    }]
+  }]
+
+  const missingCanteenId: TestPlansFactory = (date) => good(date).map(plan => ({
+    ...plan,
+    id: null
+  }))
+
+  const missingLineId: TestPlansFactory = (date) => good(date).map(plan => ({
+    ...plan,
+    lines: [plan.lines[0], { ...plan.lines[1], id: null }]
+  }))
+
+  const missingBoth: TestPlansFactory = (date) => good(date).map(plan => ({
+    ...plan,
+    id: null,
+    lines: [plan.lines[0], { ...plan.lines[1], id: null }]
+  }))
+
+  describe('fixupCache()', function () {
+    it('leaves good plans alone', async function () {
+      const plansSet = [
+        good({ year: 2022, month: 8, day: 1 }),
+        good({ year: 2022, month: 8, day: 2 }),
+        good({ year: 2022, month: 8, day: 3 })
+      ]
+      const adapter = new TestMemoryAdapter()
+      const cache = new Cache(adapter)
+      for (const plans of plansSet) {
+        await cache.put(plans[0].date, plans)
+      }
+      expect(adapter.writeOperations).to.have.lengthOf(plansSet.length)
+      const calls: DateSpec[] = []
+      await fixupCache(cache, (fixedDate) => {
+        calls.push(fixedDate)
+        return true
+      })
+      // no predicate calls and no write operations (after the initial cache setup)
+      expect(calls.length).to.equal(0)
+      expect(adapter.writeOperations).to.have.lengthOf(plansSet.length)
+    })
+
+    it('calls the predicate for changed plans but does not write if it returns false', async function () {
+      const plansSet = [
+        good({ year: 2022, month: 8, day: 1 }),
+        missingCanteenId({ year: 2022, month: 8, day: 2 }),
+        missingLineId({ year: 2022, month: 8, day: 3 }),
+        good({ year: 2022, month: 8, day: 4 }),
+        missingBoth({ year: 2022, month: 8, day: 5 })
+      ]
+      const adapter = new TestMemoryAdapter()
+      const cache = new Cache(adapter)
+      for (const plans of plansSet) {
+        await cache.put(plans[0].date, plans)
+      }
+      expect(adapter.writeOperations).to.have.lengthOf(plansSet.length)
+      const calls: DateSpec[] = []
+      await fixupCache(cache, (fixedDate) => {
+        calls.push(fixedDate)
+        return false
+      })
+      // predicate called for each bad plan but not the good ones
+      expect(calls).to.deep.equal([
+        plansSet[1][0].date, // missingCanteenId
+        plansSet[2][0].date, // missingLineId
+        plansSet[4][0].date // missingBoth
+      ])
+      // no write operations (after the initial cache setup)
+      expect(adapter.writeOperations).to.have.lengthOf(plansSet.length)
+    })
+
+    it('writes fixed files if the predicate returns true', async function () {
+      const plansSet = [
+        good({ year: 2022, month: 8, day: 1 }),
+        missingCanteenId({ year: 2022, month: 8, day: 2 }),
+        missingLineId({ year: 2022, month: 8, day: 3 }),
+        good({ year: 2022, month: 8, day: 4 }),
+        missingBoth({ year: 2022, month: 8, day: 5 })
+      ]
+      const adapter = new TestMemoryAdapter()
+      const cache = new Cache(adapter)
+      for (const plans of plansSet) {
+        await cache.put(plans[0].date, plans)
+      }
+      expect(adapter.writeOperations).to.have.lengthOf(plansSet.length)
+      const calls: DateSpec[] = []
+      await fixupCache(cache, (fixedDate) => {
+        calls.push(fixedDate)
+        return fixedDate.day === 2 || fixedDate.day === 5
+      })
+      // predicate called for each bad plan but not the good ones
+      expect(calls).to.deep.equal([
+        plansSet[1][0].date, // missingCanteenId
+        plansSet[2][0].date, // missingLineId
+        plansSet[4][0].date // missingBoth
+      ])
+      // 2 additional write operations after cache setup
+      expect(adapter.writeOperations).to.have.lengthOf(plansSet.length + 2)
+      expect(adapter.writeOperations.slice(plansSet.length)).to.deep.equal(['2022-09-02.json', '2022-09-05.json'])
+    })
+
+    it('fixes the ids but keeps everything else the same', async function () {
+      const plansSet = [
+        missingCanteenId({ year: 2022, month: 8, day: 2 }),
+        missingLineId({ year: 2022, month: 8, day: 3 }),
+        missingBoth({ year: 2022, month: 8, day: 5 })
+      ]
+      const adapter = new TestMemoryAdapter()
+      const cache = new Cache(adapter)
+      for (const plans of plansSet) {
+        await cache.put(plans[0].date, plans)
+      }
+      await fixupCache(cache, () => true)
+      // Each fixed "bad" plan should now equal the good plan!
+      for (const plans of plansSet) {
+        expect(await cache.get(plans[0].date)).to.deep.equal(good(plans[0].date))
+      }
+    })
+
+    it('keeps ids as null when the name is unknown', async function () {
+      const unknownCanteenName: CanteenPlan = {
+        date: { year: 2022, month: 8, day: 1 },
+        id: null,
+        name: 'unknown canteen name',
+        lines: []
+      }
+      const unknownLineName: CanteenPlan = {
+        date: { year: 2022, month: 8, day: 2 },
+        id: canteens[0].id,
+        name: canteens[0].name,
+        lines: [
+          { id: null, name: 'unknown line name', meals: [] }
+        ]
+      }
+      const oneKnownLineName: CanteenPlan = {
+        date: { year: 2022, month: 8, day: 3 },
+        id: canteens[0].id,
+        name: canteens[0].name,
+        lines: [
+          { id: null, name: canteens[0].lines[0].name, meals: [] },
+          { id: null, name: 'unknown line name', meals: [] }
+        ]
+      }
+      const adapter = new TestMemoryAdapter()
+      const cache = new Cache(adapter)
+      await cache.put(unknownCanteenName.date, [unknownCanteenName])
+      await cache.put(unknownLineName.date, [unknownLineName])
+      await cache.put(oneKnownLineName.date, [oneKnownLineName])
+      const calls: DateSpec[] = []
+      await fixupCache(cache, (fixedDate) => {
+        calls.push(fixedDate)
+        return true
+      })
+      // only the last one can actually be fixed, even though all of them are missing something
+      expect(calls).to.deep.equal([oneKnownLineName.date])
+      expect(adapter.writeOperations).to.have.lengthOf(4)
+      expect(adapter.writeOperations[3]).to.equal('2022-09-03.json')
+    })
+
+    it('fixes plans for a date when at least one is incomplete', async function () {
+      // Plans for a single date (different canteens) where just one canteen is incomplete
+      const plans: CanteenPlan[] = [
+        {
+          date: { year: 2022, month: 8, day: 1 },
+          id: canteens[0].id,
+          name: canteens[0].name,
+          lines: []
+        },
+        {
+          date: { year: 2022, month: 8, day: 1 },
+          id: null,
+          name: canteens[1].name,
+          lines: []
+        }
+      ]
+      const adapter = new TestMemoryAdapter()
+      const cache = new Cache(adapter)
+      await cache.put(plans[0].date, plans)
+      expect(adapter.writeOperations).to.deep.equal(['2022-09-01.json'])
+      const calls: DateSpec[] = []
+      await fixupCache(cache, (fixedDate) => {
+        calls.push(fixedDate)
+        return true
+      })
+      expect(calls).to.deep.equal([plans[0].date])
+      expect(adapter.writeOperations).to.deep.equal(['2022-09-01.json', '2022-09-01.json'])
+      const updatedPlans = await cache.get(plans[0].date) as CanteenPlan[]
+      expect(updatedPlans).to.have.lengthOf(2)
+      expect(updatedPlans[0]).to.deep.equal(plans[0])
+      expect(updatedPlans[1]).to.deep.equal({ ...plans[1], id: canteens[1].id })
+    })
+  })
+})


### PR DESCRIPTION
This adds a fixup job to server startup, closes #130. Since the
'simplesite' data source relies on backwards-lookup of canteen and line
IDs based on human-readable names that are frequently updated, an
outdated data set in ka-mensa-fetch can cause plans to be cached with
null 'id' attributes. When ka-mensa-fetch is later updated, past plans
would still contain null, even though had they been retrieved now, they
could have valid IDs inferred. That's exactly what this patch achieves
by looping over already-retrieved plans and filling in the missing
details.