### PR TITLE
fix(cache): Refactor to not use a RegExp, thereby improving list()

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -47,7 +47,7 @@ export class Cache {
       const contents = await this.fsAdapter.read(file, { encoding: 'utf8' }) as string
       return JSON.parse(contents)
     } catch (e: any) {
-      if (e != null && e.code === ENOENT) {
+      if (e?.code === ENOENT) {
         // missing file - item not found
         return undefined
       }
@@ -74,11 +74,8 @@ export class Cache {
    * @returns Resolves to an array of date objects.
    */
   async list (): Promise<DateSpec[]> {
-    const files: string[] = await this.fsAdapter.listFiles()
-    return files.filter(file => {
-      return /^\d{4}-\d{2}-\d{2}.json$/.test(file)
-    }).map(file => {
-      return parseDate(file.substring(0, file.indexOf('.')))
-    }).filter((date: DateSpec | undefined): date is DateSpec => date != null)
+    return (await this.fsAdapter.listFiles())
+      .map((file) => file.endsWith('.json') ? parseDate(file.slice(0, file.lastIndexOf('.'))) : undefined)
+      .filter((date: DateSpec | undefined): date is DateSpec => date != null)
   }
 }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -118,8 +118,11 @@ describe('cache.ts', function () {
     it('ignores files not matching the expected name format', function () {
       const adapter = new MemoryAdapter({
         '2020-09-07.txt': Buffer.alloc(0),
+        '2020-09-08xjson': Buffer.alloc(0),
         'foo.json': Buffer.alloc(0),
-        '1-1-1.json': Buffer.alloc(0)
+        '1-1-1.json': Buffer.alloc(0),
+        '2022-09-02.json.bak': Buffer.alloc(0),
+        '2022-09-03.sample.json': Buffer.alloc(0)
       })
       const cache = new Cache(adapter)
       return expect(cache.list()).to.eventually.be.an('array').that.is.empty


### PR DESCRIPTION
By removing a hard dependency on the specifics of the date format from
Cache, we avoid potential pitfalls. The regex was also broken due to an
unescaped dot! Additionally, this saves us a filter() step.