### PR TITLE
chore(tsconfig): Set "lib" explicitly to avoid DOM types in global

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2020"],
     "target": "es2020",
     "module": "es2020",
     "moduleResolution": "Node",


### PR DESCRIPTION
TSConfig "lib" by default includes DOM types which pollute the global namespace. This patch sets "lib" explicitly to avoid this behavior, which could lead to accidental bugs.