### PR TITLE
feat!: Move cache directory configuration into an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,11 @@ somewhere and run `npm install` to load dependencies.
 ### Configuration
 
 Open up `src/config.ts` and configure to your liking. Notice that network options
-are rather limited. If you want HTTPS support, CORS headers or advanced
-embedding into existing domain structures, you will need to set up a reverse
-proxy, such as nginx.
+are rather limited. If you want HTTPS support or advanced embedding into existing
+domain structures, you will need to set up a reverse proxy, such as nginx.
 
-You might want to change the plan fetch source. This will not impact
-ka-mensa-api's behavior but only how it retrieves its data.
-There are two options available:
+You might want to change the plan fetch source. This will not impact the API
+behavior but only how data is retrieved. There are two options available:
 
 - `'simplesite'` (the default)
 - `'jsonapi'`
@@ -120,6 +118,19 @@ docker run \
 
 Specify a regular URL to only allow that one origin. Use `*` to allow all
 origins.
+
+
+## Environment Variables
+
+Some options can be configured via environment variables, which will take
+precedence over the configuration file. They are as follows:
+
+- `MENSA_CACHE_DIRECTORY`: The path to a directory where downloaded plans
+    should be stored, and where they should be served from.
+    Defaults to a `cache/` directory inside the working directory.
+- `API_SERVER_CORS_ALLOWORIGIN`: Set this to a specific URL to allow CORS
+    requests from that URL, or set to `*` to allow all origins.
+    Defaults to not serving any CORS headers.
 
 
 ## Development

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 export default {
   server: {
     /**
@@ -27,13 +25,6 @@ export default {
        */
       allowOrigin: ''
     }
-  },
-
-  cache: {
-    /**
-     * Cache base path.
-     */
-    directory: path.join(process.cwd(), './cache')
   },
 
   fetchJob: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,8 +10,24 @@ import { logger } from './logger.js'
 import { onTermination, promisifiedClose, promisifiedListen } from 'omniwheel'
 import { fixupCache } from './fixup.js'
 import { formatDate } from './util/date-format.js'
+import path from 'node:path'
 
 const FIXUP_DRY_RUN = false
+const DEFAULT_CACHE_DIRECTORY = path.resolve('./cache')
+
+/**
+ * Determine the absolute path to the cache directory, from either the environment variables or the config.
+ * If the option is not configured, a default path will be returned.
+ *
+ * @returns The absolute cache directory path to use.
+ */
+function getCacheDirectory (): string {
+  const directory = process.env.MENSA_CACHE_DIRECTORY
+  if (directory != null && directory !== '') {
+    return path.resolve(directory)
+  }
+  return DEFAULT_CACHE_DIRECTORY
+}
 
 /**
  * Determine the CORS origin to allow, from either the environment variables or the config.
@@ -82,7 +98,10 @@ async function startServer (cache: Cache): Promise<void> {
  * Application entrypoint.
  */
 async function main (): Promise<void> {
-  const fsAdapter = new DirectoryAdapter(config.cache.directory)
+  const cacheDirectory = getCacheDirectory()
+  logger.info(`Using cache directory "${cacheDirectory}"`)
+
+  const fsAdapter = new DirectoryAdapter(cacheDirectory)
   await fsAdapter.init()
 
   const cache = new Cache(fsAdapter)


### PR DESCRIPTION
BREAKING CHANGE: The 'cache' config section is removed and replaced with an environment variable, MENSA_CACHE_DIRECTORY, that can be used to set the cache path.

Ref #112 