### PR TITLE
feat!: Rename CORS env variable to follow a unified naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ docker run \
         --name mensa \
         -p <host-port>:8080 \
         -v /path/on/host:/usr/src/app/cache \
-        -e API_SERVER_CORS_ALLOWORIGIN=https://example.com \
+        -e MENSA_CORS_ALLOWORIGIN=https://example.com \
         -d meyfa/ka-mensa-api
 ```
 
@@ -128,8 +128,8 @@ precedence over the configuration file. They are as follows:
 - `MENSA_CACHE_DIRECTORY`: The path to a directory where downloaded plans
     should be stored, and where they should be served from.
     Defaults to a `cache/` directory inside the working directory.
-- `API_SERVER_CORS_ALLOWORIGIN`: Set this to a specific URL to allow CORS
-    requests from that URL, or set to `*` to allow all origins.
+- `MENSA_CORS_ALLOWORIGIN`: Set this to a specific URL to allow CORS requests
+    from that URL, or set to `*` to allow all origins.
     Defaults to not serving any CORS headers.
 
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ function getCacheDirectory (): string {
  */
 function getAllowOrigin (): string | undefined {
   return [
-    process.env.API_SERVER_CORS_ALLOWORIGIN,
+    process.env.MENSA_CORS_ALLOWORIGIN,
     config.server.cors?.allowOrigin
   ].find(value => value != null && value !== '')
 }


### PR DESCRIPTION
This patch renames API_SERVER_CORS_ALLOWORIGIN to MENSA_CORS_ALLOWORIGIN so that we can have a unified naming scheme where all env variables are prefixed with 'MENSA_'.