### PR TITLE
feat!: Remove CORS option from config.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ origins.
 
 ## Environment Variables
 
-Some options can be configured via environment variables, which will take
-precedence over the configuration file. They are as follows:
+Some options can be configured via environment variables. They are as follows:
 
 - `MENSA_CACHE_DIRECTORY`: The path to a directory where downloaded plans
     should be stored, and where they should be served from.

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,19 +12,7 @@ export default {
     /**
      * Base path as sent in requests (usually /, but can also be /api etc.).
      */
-    base: '/',
-    /**
-     * Cross-Origin settings.
-     */
-    cors: {
-      /**
-       * The domains from which requests can be made to this API
-       * (the Access-Control-Allow-Origin header). Set to '*' to allow any origin,
-       * or set to a single origin such as 'https://example.com'.
-       * A value of '' or null will disallow CORS.
-       */
-      allowOrigin: ''
-    }
+    base: '/'
   },
 
   fetchJob: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,30 +16,29 @@ const FIXUP_DRY_RUN = false
 const DEFAULT_CACHE_DIRECTORY = path.resolve('./cache')
 
 /**
- * Determine the absolute path to the cache directory, from either the environment variables or the config.
- * If the option is not configured, a default path will be returned.
+ * Determine the absolute path to the cache directory from the environment variables. This will fall back to a default
+ * cache path if the env var is not set.
  *
  * @returns The absolute cache directory path to use.
  */
 function getCacheDirectory (): string {
   const directory = process.env.MENSA_CACHE_DIRECTORY
-  if (directory != null && directory !== '') {
-    return path.resolve(directory)
-  }
-  return DEFAULT_CACHE_DIRECTORY
+  return directory != null && directory !== ''
+    ? path.resolve(directory)
+    : DEFAULT_CACHE_DIRECTORY
 }
 
 /**
- * Determine the CORS origin to allow, from either the environment variables or the config.
- * This function will return a string if and only if the option is set and is not empty.
+ * Determine the CORS origin to allow from the environment variables.
+ * This function will return a string if (and only if) the option is set and is not empty.
  *
  * @returns The origin value, if it is valid, and undefined otherwise.
  */
 function getAllowOrigin (): string | undefined {
-  return [
-    process.env.MENSA_CORS_ALLOWORIGIN,
-    config.server.cors?.allowOrigin
-  ].find(value => value != null && value !== '')
+  const allowOrigin = process.env.MENSA_CORS_ALLOWORIGIN
+  return allowOrigin != null && allowOrigin !== ''
+    ? allowOrigin
+    : undefined
 }
 
 /**


### PR DESCRIPTION
With the goal of eliminating config.ts (ref #112), the CORS settings are now only available via env variables, and no longer via the config file.