### PR TITLE
chore: Remove rimraf dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "eslint": "8.35.0",
         "eslint-plugin-jsdoc": "40.0.0",
         "mocha": "10.2.0",
-        "rimraf": "4.1.2",
         "ts-node": "10.9.1",
         "typescript": "4.9.5"
       },
@@ -4100,21 +4099,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
-      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
-      "dev": true,
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7919,12 +7903,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
-      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
       "dev": true
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/server.js",
   "scripts": {
     "start": "npm run build && npm run production",
-    "build": "rimraf dist && tsc",
+    "build": "node -e \"fs.rmSync('./dist',{force:true,recursive:true})\" && tsc",
     "production": "node dist/server.js",
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore .",
@@ -55,7 +55,6 @@
     "eslint": "8.35.0",
     "eslint-plugin-jsdoc": "40.0.0",
     "mocha": "10.2.0",
-    "rimraf": "4.1.2",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
   }


### PR DESCRIPTION
Since we depend on Node.js anyway, we can use its CLI to remove the dist directory, without having to depend on a 3rd-party package.