### PR TITLE
fix: Implement custom `formatDate()` and `parseDate()` for speed

### DIFF
--- a/src/util/date-format.ts
+++ b/src/util/date-format.ts
@@ -1,10 +1,4 @@
-import moment from 'moment'
 import { DateSpec } from 'ka-mensa-fetch'
-
-/**
- * The date format that is used.
- */
-const DATE_FORMAT = 'YYYY-MM-DD'
 
 /**
  * Format the given date spec into a string YYYY-MM-DD.
@@ -13,24 +7,25 @@ const DATE_FORMAT = 'YYYY-MM-DD'
  * @returns The formatted string.
  */
 export function formatDate (date: DateSpec): string {
-  return moment(date).format('YYYY-MM-DD')
+  return `${date.year}`.padStart(4, '0') + '-' + `${date.month + 1}`.padStart(2, '0') + '-' + `${date.day}`.padStart(2, '0')
 }
 
 /**
- * Parse the given date string into a date object.
+ * Parse the given date string into a date object. This doesn't validate the date semantics.
  *
  * @param str The date string.
  * @returns The parse result.
  */
 export function parseDate (str: string): DateSpec | undefined {
-  const strict = true
-  const date = moment(str, DATE_FORMAT, strict)
-  if (date.isValid()) {
-    return {
-      year: date.year(),
-      month: date.month(),
-      day: date.date()
-    }
+  // This doesn't care about some aspects of the date, like leap years.
+  // That's not a problem for our use-case.
+  const match = str.match(/^(\d{4})-(0[1-9]|1[012])-([012][1-9]|3[01])$/)
+  if (match == null) {
+    return undefined
   }
-  return undefined
+  return {
+    year: parseInt(match[1], 10),
+    month: parseInt(match[2], 10) - 1,
+    day: parseInt(match[3], 10)
+  }
 }

--- a/test/util/date-format.test.ts
+++ b/test/util/date-format.test.ts
@@ -41,15 +41,6 @@ describe('date-format.ts', function () {
       assert.strictEqual(parseDate('2019-01-32'), undefined)
     })
 
-    it('handles leap years', function () {
-      assert.deepStrictEqual(parseDate('2020-02-29'), {
-        year: 2020,
-        month: 1,
-        day: 29
-      })
-      assert.strictEqual(parseDate('2019-02-29'), undefined)
-    })
-
     it('does not parse invalid inputs', function () {
       assert.strictEqual(parseDate('2019.01.30'), undefined)
       assert.strictEqual(parseDate('3247abc'), undefined)


### PR DESCRIPTION
By avoiding the use of `moment`, we achieve the following performance gains:

* `formatDate()`: approx. 58x speedup
* `parseDate()`: approx. 22x speedup

We also lose semantic validation of the date in `parseDate()`, i.e., the function will no longer reject inputs such as `'2023-02-31'`. This isn't relevant in our case, though, since it will still lead to a 404 response at a later point.