### PR TITLE
test: Add integration tests for the HTTP routes

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,66 @@
+import { onTermination } from 'omniwheel'
+import { logger } from './logger.js'
+import config from './config.js'
+import { Cache } from './cache.js'
+import fastify, { FastifyInstance } from 'fastify'
+import cors from '@fastify/cors'
+import { sendError } from './response.js'
+import { ApiError, BadRequestError, InternalServerError, NotFoundError } from './errors.js'
+import { defaultRoute } from './routes/default.js'
+import { metaRoute } from './routes/meta/index.js'
+import { canteensRoute } from './routes/canteens.js'
+import { plansRoute } from './routes/plans.js'
+
+/**
+ * Options for the HTTP server.
+ */
+export interface HttpServerOptions {
+  allowOrigin?: string
+}
+
+/**
+ * Start the web server.
+ *
+ * @param cache The plan cache to use.
+ * @param options Options for the HTTP server.
+ * @returns The Fastify instance.
+ */
+export async function startServer (cache: Cache, options: HttpServerOptions): Promise<FastifyInstance> {
+  const app = fastify()
+
+  // CORS
+  if (options.allowOrigin != null) {
+    await app.register(cors, { origin: options.allowOrigin })
+  }
+
+  // error handling
+  app.setErrorHandler(async (error, req, reply) => {
+    if (error instanceof SyntaxError && error.statusCode != null && error.statusCode >= 400 && error.statusCode < 500) {
+      // JSON input error
+      return await sendError(reply, new BadRequestError('malformed input'))
+    } else if (error instanceof ApiError) {
+      // one of our own errors
+      return await sendError(reply, error)
+    } else {
+      logger.error(error)
+      return await sendError(reply, new InternalServerError())
+    }
+  })
+  app.setNotFoundHandler(async (req, reply) => await sendError(reply, new NotFoundError('route')))
+
+  // routes
+  await app.register(defaultRoute(), { prefix: '/' })
+  await app.register(metaRoute(), { prefix: '/meta' })
+  await app.register(canteensRoute(), { prefix: '/canteens' })
+  await app.register(plansRoute(cache), { prefix: '/plans' })
+
+  const port = config.server.port
+  const host = config.server.host
+  await app.listen({ port, host })
+
+  logger.info(`Server listening on :${port}`)
+
+  onTermination(async () => await app.close())
+
+  return await app
+}

--- a/test/routes/404.test.ts
+++ b/test/routes/404.test.ts
@@ -1,0 +1,23 @@
+import { startServer } from '../../src/http-server.js'
+import { Cache } from '../../src/cache.js'
+import { MemoryAdapter } from 'fs-adapters'
+import assert from 'node:assert'
+import { HttpStatus } from 'omniwheel'
+import { FastifyInstance } from 'fastify'
+
+const route = '/does-not-exist'
+
+describe(`route: ${route}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns a 404 response', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: route })
+    assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
+    assert.deepStrictEqual(response.json(), {
+      error: 'route not found'
+    })
+  })
+})

--- a/test/routes/canteens.test.ts
+++ b/test/routes/canteens.test.ts
@@ -1,0 +1,108 @@
+import { startServer } from '../../src/http-server.js'
+import { Cache } from '../../src/cache.js'
+import { MemoryAdapter } from 'fs-adapters'
+import assert from 'node:assert'
+import { HttpStatus } from 'omniwheel'
+import { canteens } from 'ka-mensa-fetch'
+import { FastifyInstance } from 'fastify'
+
+const route = '/canteens'
+
+describe(`route: ${route}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns expected data', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: route })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: canteens
+    })
+  })
+})
+
+describe(`route: ${route}/{canteenId}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns 404 for unknown canteen', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: `${route}/foo` })
+    assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
+    assert.deepStrictEqual(response.json(), {
+      error: 'canteen not found'
+    })
+  })
+
+  it('returns the canteen data for known canteen', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: `${route}/adenauerring` })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: canteens.find(c => c.id === 'adenauerring')
+    })
+  })
+})
+
+describe(`route: ${route}/{canteenId}/lines`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns 404 for unknown canteen', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: `${route}/foo/lines` })
+    assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
+    assert.deepStrictEqual(response.json(), {
+      error: 'canteen not found'
+    })
+  })
+
+  it('returns the canteen line data for known canteen', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: `${route}/adenauerring/lines` })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: canteens.find(c => c.id === 'adenauerring')?.lines
+    })
+  })
+})
+
+describe(`route: ${route}/{canteenId}/lines/{lineId}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns 404 for unknown canteen or unknown line', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response1 = await fastify.inject({ path: `${route}/foo/lines/l1` })
+    assert.strictEqual(response1.statusCode, HttpStatus.NOT_FOUND)
+    assert.deepStrictEqual(response1.json(), {
+      error: 'canteen not found'
+    })
+    const response2 = await fastify.inject({ path: `${route}/adenauerring/lines/bar` })
+    assert.strictEqual(response2.statusCode, HttpStatus.NOT_FOUND)
+    assert.deepStrictEqual(response2.json(), {
+      error: 'line not found'
+    })
+  })
+
+  it('returns the canteen line data for known canteen line', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: `${route}/adenauerring/lines/l1` })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: canteens.find(c => c.id === 'adenauerring')?.lines.find(l => l.id === 'l1')
+    })
+  })
+})

--- a/test/routes/default.test.ts
+++ b/test/routes/default.test.ts
@@ -1,0 +1,24 @@
+import { startServer } from '../../src/http-server.js'
+import { Cache } from '../../src/cache.js'
+import { MemoryAdapter } from 'fs-adapters'
+import assert from 'node:assert'
+import { HttpStatus } from 'omniwheel'
+import { FastifyInstance } from 'fastify'
+
+const route = '/'
+
+describe(`route: ${route}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns empty data object', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: route })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: {}
+    })
+  })
+})

--- a/test/routes/meta/legend.test.ts
+++ b/test/routes/meta/legend.test.ts
@@ -1,0 +1,25 @@
+import { startServer } from '../../../src/http-server.js'
+import { Cache } from '../../../src/cache.js'
+import { MemoryAdapter } from 'fs-adapters'
+import assert from 'node:assert'
+import { HttpStatus } from 'omniwheel'
+import { legend } from 'ka-mensa-fetch'
+import { FastifyInstance } from 'fastify'
+
+const route = '/meta/legend'
+
+describe(`route: ${route}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns expected data', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: route })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: legend
+    })
+  })
+})

--- a/test/routes/plans.test.ts
+++ b/test/routes/plans.test.ts
@@ -1,0 +1,236 @@
+import { startServer } from '../../src/http-server.js'
+import { Cache } from '../../src/cache.js'
+import { MemoryAdapter } from 'fs-adapters'
+import assert from 'node:assert'
+import { HttpStatus } from 'omniwheel'
+import { FastifyInstance, LightMyRequestResponse } from 'fastify'
+import { canteens } from 'ka-mensa-fetch'
+
+const route = '/plans'
+
+describe(`route: ${route}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('returns expected data (empty cache)', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: route })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: []
+    })
+  })
+
+  it('returns expected data (non-empty cache)', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    await cache.put({ year: 2022, month: 2, day: 17 }, [])
+    await cache.put({ year: 2023, month: 2, day: 13 }, [])
+    await cache.put({ year: 2023, month: 2, day: 14 }, [])
+    await cache.put({ year: 2023, month: 3, day: 3 }, [])
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: route })
+    assert.strictEqual(response.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response.json(), {
+      success: true,
+      data: [
+        { date: { year: 2022, month: 2, day: 17 } },
+        { date: { year: 2023, month: 2, day: 13 } },
+        { date: { year: 2023, month: 2, day: 14 } },
+        { date: { year: 2023, month: 3, day: 3 } }
+      ]
+    })
+  })
+})
+
+describe(`route: ${route}/{date}`, function () {
+  let fastify: FastifyInstance | undefined
+  afterEach(async () => await fastify?.close())
+
+  it('disallows non-date paths', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    for (const input of ['foo', '2021-02-17T12:00:00Z', '--', 'YYYY-MM-DD']) {
+      const response: LightMyRequestResponse = await fastify.inject({ path: `${route}/${input}` })
+      assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND, `input: ${input}`)
+      assert.deepStrictEqual(response.json(), {
+        error: 'route not found'
+      }, `input: ${input}`)
+    }
+    for (const input of ['0000-00-00', '2023-00-01', '2023-13-01', '2023-04-00', '2023-04-32']) {
+      const response: LightMyRequestResponse = await fastify.inject({ path: `${route}/${input}` })
+      assert.strictEqual(response.statusCode, HttpStatus.BAD_REQUEST, `input: ${input}`)
+      assert.deepStrictEqual(response.json(), {
+        error: 'malformed date'
+      })
+    }
+  })
+
+  it('returns 404 for non-cached dates', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    await cache.put({ year: 2023, month: 2, day: 13 }, [])
+    fastify = await startServer(cache, {})
+    const response = await fastify.inject({ path: `${route}/2023-03-15` })
+    assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
+    assert.deepStrictEqual(response.json(), {
+      error: 'plan not found'
+    })
+  })
+
+  it('returns the plan when available', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    await cache.put({ year: 2023, month: 2, day: 13 }, [])
+    await cache.put({ year: 2023, month: 2, day: 14 }, [
+      {
+        id: canteens[0].id,
+        date: { year: 2023, month: 2, day: 14 },
+        name: canteens[0].name,
+        lines: canteens[0].lines.map((line) => ({
+          id: line.id,
+          name: line.name,
+          meals: [
+            {
+              name: 'foo bar baz',
+              price: '1,50 €',
+              additives: ['We', 'So'],
+              classifiers: ['VG']
+            }
+          ]
+        }))
+      }
+    ])
+    fastify = await startServer(cache, {})
+    const response1 = await fastify.inject({ path: `${route}/2023-03-13` })
+    assert.strictEqual(response1.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response1.json(), {
+      success: true,
+      data: []
+    })
+    const response2 = await fastify.inject({ path: `${route}/2023-03-14` })
+    assert.strictEqual(response2.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response2.json(), {
+      success: true,
+      data: [
+        // The response uses a slightly different format than the cache
+        {
+          canteen: {
+            id: canteens[0].id,
+            name: canteens[0].name
+          },
+          date: { year: 2023, month: 2, day: 14 },
+          lines: canteens[0].lines.map((line) => ({
+            id: line.id,
+            name: line.name,
+            meals: [
+              {
+                name: 'foo bar baz',
+                price: '1,50 €',
+                additives: ['We', 'So'],
+                classifiers: ['VG']
+              }
+            ]
+          }))
+        }
+      ]
+    })
+  })
+
+  it('disallows invalid canteen filters', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    fastify = await startServer(cache, {})
+    for (const input of ['', 'foo', ',adenauerring', 'adenauerring,', 'foo bar']) {
+      const response: LightMyRequestResponse = await fastify.inject({
+        path: `${route}/2023-03-15`,
+        query: { canteens: input }
+      })
+      assert.strictEqual(response.statusCode, HttpStatus.BAD_REQUEST, `input: ${input}`)
+      assert.deepStrictEqual(response.json(), {
+        error: 'invalid filter: canteens'
+      })
+    }
+    // also try with a repeated query parameter
+    const response: LightMyRequestResponse = await fastify.inject({
+      path: `${route}/2023-03-15`,
+      query: {
+        canteens: ['adenauerring', 'moltke']
+      }
+    })
+    assert.strictEqual(response.statusCode, HttpStatus.BAD_REQUEST)
+    assert.deepStrictEqual(response.json(), {
+      error: 'invalid filter: canteens'
+    })
+  })
+
+  it('returns the plan with canteen filters', async function () {
+    const cache = new Cache(new MemoryAdapter())
+    await cache.put({ year: 2023, month: 2, day: 13 }, [])
+    await cache.put({ year: 2023, month: 2, day: 14 }, [
+      {
+        id: canteens[0].id,
+        date: { year: 2023, month: 2, day: 14 },
+        name: canteens[0].name,
+        lines: []
+      }
+    ])
+    fastify = await startServer(cache, {})
+    // empty plan, but with a canteen filter
+    const response1 = await fastify.inject({
+      path: `${route}/2023-03-13`,
+      query: { canteens: 'adenauerring' }
+    })
+    assert.strictEqual(response1.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response1.json(), {
+      success: true,
+      data: []
+    })
+    // non-empty plan, with a matching filter
+    const response2 = await fastify.inject({
+      path: `${route}/2023-03-14`,
+      query: { canteens: canteens[0].id }
+    })
+    assert.strictEqual(response2.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response2.json(), {
+      success: true,
+      data: [
+        {
+          canteen: {
+            id: canteens[0].id,
+            name: canteens[0].name
+          },
+          date: { year: 2023, month: 2, day: 14 },
+          lines: []
+        }
+      ]
+    })
+    // non-empty plan, with a non-matching filter
+    const response3 = await fastify.inject({
+      path: `${route}/2023-03-14`,
+      query: { canteens: canteens[1].id }
+    })
+    assert.strictEqual(response3.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response3.json(), {
+      success: true,
+      data: []
+    })
+    // non-empty plan, with a partially matching filter
+    const response4 = await fastify.inject({
+      path: `${route}/2023-03-14`,
+      query: { canteens: `${canteens[0].id},${canteens[1].id}` }
+    })
+    assert.strictEqual(response4.statusCode, HttpStatus.OK)
+    assert.deepStrictEqual(response4.json(), {
+      success: true,
+      data: [
+        {
+          canteen: {
+            id: canteens[0].id,
+            name: canteens[0].name
+          },
+          date: { year: 2023, month: 2, day: 14 },
+          lines: []
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
The recent migration from Express to Fastify caused some bugs in the HTTP server, such as a wrong response format. This could've been caught with integration tests. To prevent such problems in the future, this patch adds tests for all routes to assert correct responses for valid and also for invalid input. Implementing this required moving the HTTP server into a separate module that's free of side effects.