### PR TITLE
chore!: Raise Node.js requirement to v18.16.1 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "5.1.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.16.1"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/meyfa/ka-mensa-api",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.16.1"
   },
   "dependencies": {
     "@fastify/cors": "8.3.0",


### PR DESCRIPTION
This is required for updating dependency group-items to v3 (#257), and fs-adapters to v7 (#256).