### PR TITLE
feat!: Use environment variables for configuration (exclusively)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The entire project is written in JavaScript+TypeScript and is composed as follow
 - [ka-mensa-fetch](https://github.com/meyfa/ka-mensa-fetch): library package
     responsible for the fetching of raw plan data and conversion into canonical,
     easily digestible JSON documents
-- [ka-mensa-api](https://github.com/meyfa/ka-mensa-api): NodeJS server that
+- [ka-mensa-api](https://github.com/meyfa/ka-mensa-api): Node.js server that
     utilizes the fetcher to continuously collect meal plans and makes them
     available via REST API
 - [ka-mensa-ui](https://github.com/meyfa/ka-mensa-ui): single-page web app
@@ -36,9 +36,37 @@ somewhere and run `npm install` to load dependencies.
 
 ### Configuration
 
-Open up `src/config.ts` and configure to your liking. Notice that network options
-are rather limited. If you want HTTPS support or advanced embedding into existing
-domain structures, you will need to set up a reverse proxy, such as nginx.
+ka-mensa-api is configured exclusively via environment variables that need to
+be set before starting the server. The following variables are available:
+
+- `CACHE_DIRECTORY`: The path to a directory where downloaded plans should be 
+  stored, and where they should be served from. Defaults to a `cache/` inside
+  the current working directory.
+- `SERVER_HOST`: The address to listen on, e.g. `::` (or `0.0.0.0`) for all
+  interfaces, `::1` (or `127.0.0.1`) for localhost only. Defaults to `::`.
+- `SERVER_PORT`: The port to listen on. Defaults to `8080`.
+- `CORS_ALLOWORIGIN`: Set this to a specific URL to allow CORS requests from
+  that URL, or set to `*` to allow all origins. Defaults to no CORS headers.
+- `FETCH_INTERVAL`: The time between runs of the fetcher. Default: `6 hours`.
+- `FETCH_SOURCE`: The source to fetch plans from. Available options are
+  `simplesite` and `jsonapi`. Default: `'simplesite'`.
+
+If using the `simplesite` source:
+
+- `SIMPLESITE_DAYS`: The number of days to fetch from the simplesite
+  source. More may be fetched, depending on how many the server returns for
+  the specific request. Default: `14`.
+
+If using the `jsonapi` source:
+
+- `JSONAPI_AUTH_USERNAME`: Credentials for JSON API authentication.
+- `JSONAPI_AUTH_PASSWORD`: Credentials for JSON API authentication.
+
+Notice that network options are rather limited. If you want HTTPS support or
+advanced embedding into existing domain structures, you will need to set up a
+reverse proxy such as nginx.
+
+### Data Source
 
 You might want to change the plan fetch source. This will not impact the API
 behavior but only how data is retrieved. There are two options available:
@@ -63,7 +91,7 @@ and auth requirements.
 
 To start the server, run `npm start`. It will immediately fetch the most recent
 set of plans, then listen for API requests. Plan polling will continue
-indefinitely with the interval set in `src/config.ts`.
+indefinitely with the configured interval.
 
 Note that `npm start` is shortcut for `npm run build` followed by `npm run production`,
 where the former compiles the TypeScript code and the latter executes it.
@@ -77,7 +105,7 @@ will not be changed.
 
 ## Setup with Docker
 
-This project is available as a Docker image! See also
+This project is available as a Docker image. See also
 [https://hub.docker.com/r/meyfa/ka-mensa-api](https://hub.docker.com/r/meyfa/ka-mensa-api).
 
 ### Running the Container
@@ -100,36 +128,26 @@ docker run \
         -d meyfa/ka-mensa-api
 ```
 
+Any configuration can be done via environment variables (`-e VAR=value`). The
+available variables are the same as for the standard setup.
+
 ### CORS Headers
 
 Perhaps you need to configure CORS for the API server - to enable displaying
 the plans via an instance of `ka-mensa-ui` running on another domain, for
-example. This can be done via the config file or by setting an environment
-variable:
+example:
 
 ```
 docker run \
         --name mensa \
         -p <host-port>:8080 \
         -v /path/on/host:/usr/src/app/cache \
-        -e MENSA_CORS_ALLOWORIGIN=https://example.com \
+        -e CORS_ALLOWORIGIN=https://example.com \
         -d meyfa/ka-mensa-api
 ```
 
 Specify a regular URL to only allow that one origin. Use `*` to allow all
 origins.
-
-
-## Environment Variables
-
-Some options can be configured via environment variables. They are as follows:
-
-- `MENSA_CACHE_DIRECTORY`: The path to a directory where downloaded plans
-    should be stored, and where they should be served from.
-    Defaults to a `cache/` directory inside the working directory.
-- `MENSA_CORS_ALLOWORIGIN`: Set this to a specific URL to allow CORS requests
-    from that URL, or set to `*` to allow all origins.
-    Defaults to not serving any CORS headers.
 
 
 ## Development

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,45 +1,137 @@
-export default {
-  server: {
-    /**
-     * Address to listen on, e.g. :: (or 0.0.0.0) for all addresses,
-     * ::1 (or 127.0.0.1) for localhost only (use case: reverse proxy), etc.
-     */
-    host: '::',
-    /**
-     * Port to listen on.
-     */
-    port: 8080,
-    /**
-     * Base path as sent in requests (usually /, but can also be /api etc.).
-     */
-    base: '/'
-  },
+import path from 'node:path'
+import ms from 'ms'
 
-  fetchJob: {
-    /**
-     * Time between runs of the fetcher.
-     */
-    interval: '6 hours',
-    /**
-     * The data source to be used by the fetch job.
-     * Either 'simplesite' (the default) or 'jsonapi' (more reliable, but slightly
-     * different output and requires authentication).
-     */
-    source: 'simplesite',
-    simplesiteOptions: {
-      /**
-       * How many days into the future to fetch when using the simplesite source.
-       */
-      futureDays: 14
+const VALID_SOURCES = ['simplesite', 'jsonapi'] as const
+const DEFAULT_CACHE_DIRECTORY = './cache'
+
+/**
+ * Configuration for the application.
+ */
+export interface Config {
+  cacheDirectory: string
+  server: {
+    host: string
+    port: number
+  }
+  corsAllowOrigin: string | undefined
+  fetch: {
+    interval: number
+    source: typeof VALID_SOURCES[number]
+  }
+  simplesite: {
+    days: number
+  }
+  jsonapi: {
+    auth: {
+      username: string
+      password: string
+    }
+  }
+}
+
+/**
+ * Parse the configuration from environment variables.
+ *
+ * @returns The configuration object.
+ */
+export function getConfig (): Config {
+  return {
+    cacheDirectory: getCacheDirectory(),
+    server: {
+      host: getEnvOrDefault('SERVER_HOST', '::'),
+      port: validatePositiveInteger(getEnvOrDefault('SERVER_PORT', '8080'))
     },
-    jsonapiOptions: {
-      /**
-       * Mandatory authentication credentials for the JSON API.
-       */
+    corsAllowOrigin: getCorsAllowOrigin(),
+    fetch: {
+      interval: validateDuration(getEnvOrDefault('FETCH_INTERVAL', '6 hours')),
+      source: validateEnum(VALID_SOURCES, getEnvOrDefault('FETCH_SOURCE', 'simplesite'))
+    },
+    simplesite: {
+      days: validatePositiveInteger(getEnvOrDefault('SIMPLESITE_DAYS', '14'))
+    },
+    jsonapi: {
       auth: {
-        user: '',
-        password: ''
+        username: getEnvOrDefault('JSONAPI_AUTH_USERNAME', ''),
+        password: getEnvOrDefault('JSONAPI_AUTH_PASSWORD', '')
       }
     }
   }
+}
+
+/**
+ * Determine the absolute path to the cache directory from the environment variables. This will fall back to a default
+ * cache path if the env var is not set.
+ *
+ * @returns The absolute cache directory path to use.
+ */
+function getCacheDirectory (): string {
+  // backwards compatibility
+  const oldDirectory = getEnvOrDefault('MENSA_CACHE_DIRECTORY', DEFAULT_CACHE_DIRECTORY)
+  const directory = getEnvOrDefault('CACHE_DIRECTORY', oldDirectory)
+  return path.resolve(directory)
+}
+
+/**
+ * Determine the CORS origin to allow from the environment variables.
+ * This function will return a string if (and only if) the option is set and is not empty.
+ *
+ * @returns The origin value, if it is valid, and undefined otherwise.
+ */
+function getCorsAllowOrigin (): string | undefined {
+  const oldAllowOrigin = getEnvOrDefault('MENSA_CORS_ALLOWORIGIN', undefined)
+  return getEnvOrDefault('CORS_ALLOWORIGIN', oldAllowOrigin)
+}
+
+/**
+ * Get an environment variable or a default value if it is not set, or is empty.
+ *
+ * @param key The environment variable key.
+ * @param defaultValue The default value to use.
+ * @returns The value of the environment variable, or the default value.
+ */
+function getEnvOrDefault<D = string> (key: string, defaultValue: D): string | D {
+  const value = process.env[key]
+  return value != null && value !== '' ? value : defaultValue
+}
+
+/**
+ * Convert a string to a positive integer.
+ *
+ * @param str The string to convert.
+ * @returns The parsed integer.
+ */
+function validatePositiveInteger (str: string): number {
+  const value = Number.parseInt(str, 10)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`invalid positive integer: "${str}"`)
+  }
+  return value
+}
+
+/**
+ * Validate that a string is one of the given values.
+ *
+ * @param allowed The allowed values.
+ * @param str The string to validate.
+ * @returns The string if it is valid.
+ */
+function validateEnum <T extends readonly string[]> (allowed: T, str: string): T[number] {
+  if (!allowed.includes(str)) {
+    throw new Error(`invalid value: "${str}", allowed: ${allowed.join(', ')}`)
+  }
+  return str
+}
+
+/**
+ * Validate a duration string.
+ *
+ * @param str The duration string.
+ * @returns The parsed duration in milliseconds.
+ */
+function validateDuration (str: string): number {
+  const duration = ms(str)
+  if (duration == null || Number.isNaN(duration) || duration <= 0) {
+    throw new Error(`invalid duration: "${str}"`)
+  }
+  return duration
 }

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,5 +1,4 @@
 import { onTermination } from 'omniwheel'
-import config from './config.js'
 import { Cache } from './cache.js'
 import fastify, { FastifyInstance } from 'fastify'
 import cors from '@fastify/cors'
@@ -15,6 +14,8 @@ import { Logger } from 'winston'
  * Options for the HTTP server.
  */
 export interface HttpServerOptions {
+  host: string
+  port: number
   allowOrigin?: string
 }
 
@@ -27,11 +28,13 @@ export interface HttpServerOptions {
  * @returns The Fastify instance.
  */
 export async function startServer (logger: Logger, cache: Cache, options: HttpServerOptions): Promise<FastifyInstance> {
+  const { host, port, allowOrigin } = options
+
   const app = fastify()
 
   // CORS
-  if (options.allowOrigin != null) {
-    await app.register(cors, { origin: options.allowOrigin })
+  if (allowOrigin != null) {
+    await app.register(cors, { origin: allowOrigin })
   }
 
   // error handling
@@ -55,8 +58,6 @@ export async function startServer (logger: Logger, cache: Cache, options: HttpSe
   await app.register(canteensRoute(), { prefix: '/canteens' })
   await app.register(plansRoute(cache), { prefix: '/plans' })
 
-  const port = config.server.port
-  const host = config.server.host
   await app.listen({ port, host })
 
   logger.info(`Server listening on :${port}`)

--- a/test/routes/404.test.ts
+++ b/test/routes/404.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert'
 import { HttpStatus } from 'omniwheel'
 import { FastifyInstance } from 'fastify'
 import winston from 'winston'
+import { defaultOptions } from './fixtures.js'
 
 const route = '/does-not-exist'
 
@@ -14,7 +15,7 @@ describe(`route: ${route}`, function () {
 
   it('returns a 404 response', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: route })
     assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
     assert.deepStrictEqual(response.json(), {

--- a/test/routes/canteens.test.ts
+++ b/test/routes/canteens.test.ts
@@ -6,6 +6,7 @@ import { HttpStatus } from 'omniwheel'
 import { canteens } from 'ka-mensa-fetch'
 import { FastifyInstance } from 'fastify'
 import winston from 'winston'
+import { defaultOptions } from './fixtures.js'
 
 const route = '/canteens'
 
@@ -15,7 +16,7 @@ describe(`route: ${route}`, function () {
 
   it('returns expected data', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: route })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {
@@ -31,7 +32,7 @@ describe(`route: ${route}/{canteenId}`, function () {
 
   it('returns 404 for unknown canteen', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: `${route}/foo` })
     assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
     assert.deepStrictEqual(response.json(), {
@@ -41,7 +42,7 @@ describe(`route: ${route}/{canteenId}`, function () {
 
   it('returns the canteen data for known canteen', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: `${route}/adenauerring` })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {
@@ -57,7 +58,7 @@ describe(`route: ${route}/{canteenId}/lines`, function () {
 
   it('returns 404 for unknown canteen', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: `${route}/foo/lines` })
     assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
     assert.deepStrictEqual(response.json(), {
@@ -67,7 +68,7 @@ describe(`route: ${route}/{canteenId}/lines`, function () {
 
   it('returns the canteen line data for known canteen', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: `${route}/adenauerring/lines` })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {
@@ -83,7 +84,7 @@ describe(`route: ${route}/{canteenId}/lines/{lineId}`, function () {
 
   it('returns 404 for unknown canteen or unknown line', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response1 = await fastify.inject({ path: `${route}/foo/lines/l1` })
     assert.strictEqual(response1.statusCode, HttpStatus.NOT_FOUND)
     assert.deepStrictEqual(response1.json(), {
@@ -98,7 +99,7 @@ describe(`route: ${route}/{canteenId}/lines/{lineId}`, function () {
 
   it('returns the canteen line data for known canteen line', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: `${route}/adenauerring/lines/l1` })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {

--- a/test/routes/default.test.ts
+++ b/test/routes/default.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert'
 import { HttpStatus } from 'omniwheel'
 import { FastifyInstance } from 'fastify'
 import winston from 'winston'
+import { defaultOptions } from './fixtures.js'
 
 const route = '/'
 
@@ -14,7 +15,7 @@ describe(`route: ${route}`, function () {
 
   it('returns empty data object', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: route })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {

--- a/test/routes/fixtures.ts
+++ b/test/routes/fixtures.ts
@@ -1,0 +1,6 @@
+import { HttpServerOptions } from '../../src/http-server.js'
+
+export const defaultOptions: HttpServerOptions = {
+  host: '127.0.0.1',
+  port: 8080
+}

--- a/test/routes/meta/legend.test.ts
+++ b/test/routes/meta/legend.test.ts
@@ -6,6 +6,7 @@ import { HttpStatus } from 'omniwheel'
 import { legend } from 'ka-mensa-fetch'
 import { FastifyInstance } from 'fastify'
 import winston from 'winston'
+import { defaultOptions } from '../fixtures.js'
 
 const route = '/meta/legend'
 
@@ -15,7 +16,7 @@ describe(`route: ${route}`, function () {
 
   it('returns expected data', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: route })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {

--- a/test/routes/plans.test.ts
+++ b/test/routes/plans.test.ts
@@ -6,6 +6,7 @@ import { HttpStatus } from 'omniwheel'
 import { FastifyInstance, LightMyRequestResponse } from 'fastify'
 import { canteens } from 'ka-mensa-fetch'
 import winston from 'winston'
+import { defaultOptions } from './fixtures.js'
 
 const route = '/plans'
 
@@ -15,7 +16,7 @@ describe(`route: ${route}`, function () {
 
   it('returns expected data (empty cache)', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: route })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {
@@ -30,7 +31,7 @@ describe(`route: ${route}`, function () {
     await cache.put({ year: 2023, month: 2, day: 13 }, [])
     await cache.put({ year: 2023, month: 2, day: 14 }, [])
     await cache.put({ year: 2023, month: 3, day: 3 }, [])
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: route })
     assert.strictEqual(response.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response.json(), {
@@ -51,7 +52,7 @@ describe(`route: ${route}/{date}`, function () {
 
   it('disallows non-date paths', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     for (const input of ['foo', '2021-02-17T12:00:00Z', '--', 'YYYY-MM-DD']) {
       const response: LightMyRequestResponse = await fastify.inject({ path: `${route}/${input}` })
       assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND, `input: ${input}`)
@@ -71,7 +72,7 @@ describe(`route: ${route}/{date}`, function () {
   it('returns 404 for non-cached dates', async function () {
     const cache = new Cache(new MemoryAdapter())
     await cache.put({ year: 2023, month: 2, day: 13 }, [])
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response = await fastify.inject({ path: `${route}/2023-03-15` })
     assert.strictEqual(response.statusCode, HttpStatus.NOT_FOUND)
     assert.deepStrictEqual(response.json(), {
@@ -101,7 +102,7 @@ describe(`route: ${route}/{date}`, function () {
         }))
       }
     ])
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     const response1 = await fastify.inject({ path: `${route}/2023-03-13` })
     assert.strictEqual(response1.statusCode, HttpStatus.OK)
     assert.deepStrictEqual(response1.json(), {
@@ -139,7 +140,7 @@ describe(`route: ${route}/{date}`, function () {
 
   it('disallows invalid canteen filters', async function () {
     const cache = new Cache(new MemoryAdapter())
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     for (const input of ['', 'foo', ',adenauerring', 'adenauerring,', 'foo bar']) {
       const response: LightMyRequestResponse = await fastify.inject({
         path: `${route}/2023-03-15`,
@@ -174,7 +175,7 @@ describe(`route: ${route}/{date}`, function () {
         lines: []
       }
     ])
-    fastify = await startServer(winston.createLogger({ silent: true }), cache, {})
+    fastify = await startServer(winston.createLogger({ silent: true }), cache, defaultOptions)
     // empty plan, but with a canteen filter
     const response1 = await fastify.inject({
       path: `${route}/2023-03-13`,


### PR DESCRIPTION
Fixes #112. `config.ts` is no longer part of the configuration workflow when deploying the application. Instead, everything is configurable through environment variables. See #112 for further reasoning.